### PR TITLE
Support ADB-based monkey scripts

### DIFF
--- a/AndroidRunner/MonkeyAdb.py
+++ b/AndroidRunner/MonkeyAdb.py
@@ -1,0 +1,45 @@
+import json
+import time
+from .Script import Script
+
+class MonkeyAdbError(Exception):
+    pass
+
+class MonkeyAdb(Script):
+    """Replay a monkey.txt file using adb shell input commands."""
+    def execute_script(self, device, *args, **kwargs):
+        super(MonkeyAdb, self).execute_script(device, *args, **kwargs)
+        with open(self.path, 'r') as f:
+            prev_up = 0
+            for line in f:
+                if not line.strip():
+                    continue
+                action = json.loads(line)
+                wait = max(0, (float(action.get('down', 0)) - float(prev_up))/1000)
+                if wait:
+                    time.sleep(wait)
+                if action['type'] == 'touch':
+                    device.shell('input tap %s %s' % (action['x'], action['y']))
+                    duration = (float(action.get('up', 0)) - float(action.get('down',0)))/1000
+                    if duration:
+                        time.sleep(duration)
+                elif action['type'] == 'drag':
+                    p1, p2 = action['points']
+                    duration = int(float(action.get('up',0)) - float(action.get('down',0)))
+                    device.shell('input swipe %s %s %s %s %s' % (
+                        p1['x'], p1['y'], p2['x'], p2['y'], duration))
+                elif action['type'] == 'press':
+                    for k in action['keys']:
+                        device.shell('input keyevent %s' % k['key'])
+                    duration = (float(action.get('up',0)) - float(action.get('down',0)))/1000
+                    if duration:
+                        time.sleep(duration)
+                elif action['type'] == 'text':
+                    device.shell("input text '%s'" % action['value'])
+                    duration = (float(action.get('up',0)) - float(action.get('down',0)))/1000
+                    if duration:
+                        time.sleep(duration)
+                else:
+                    raise MonkeyAdbError('Unknown action type %s' % action['type'])
+                prev_up = float(action.get('up', prev_up))
+        return 0

--- a/AndroidRunner/Scripts.py
+++ b/AndroidRunner/Scripts.py
@@ -4,6 +4,7 @@ import os.path as op
 import paths
 from .MonkeyReplay import MonkeyReplay
 from .MonkeyRunner import MonkeyRunner
+from .MonkeyAdb import MonkeyAdb
 from .Python3 import Python3
 from .util import ConfigError
 
@@ -29,6 +30,8 @@ class Scripts(object):
                     script = MonkeyReplay(path, timeout, logcat_regex, monkeyrunner_path)
                 elif s['type'] == 'monkeyrunner':
                     script = MonkeyRunner(path, timeout, logcat_regex, monkeyrunner_path, monkey_playback_path)
+                elif s['type'] == 'monkeyadb':
+                    script = MonkeyAdb(path, timeout, logcat_regex)
                 else:
                     raise ConfigError('Unknown script type: {}'.format(s['type']))
 

--- a/examples/adbmonkey/config.json
+++ b/examples/adbmonkey/config.json
@@ -1,0 +1,18 @@
+{
+  "type": "android",
+  "devices": {
+    "Pixel3W": {}
+  },
+  "repetitions": 1,
+  "apps": [
+    "com.android.chrome"
+  ],
+  "scripts": {
+    "interaction": [
+      {
+        "type": "monkeyadb",
+        "path": "monkey.txt"
+      }
+    ]
+  }
+}

--- a/examples/adbmonkey/monkey.txt
+++ b/examples/adbmonkey/monkey.txt
@@ -1,0 +1,1 @@
+{"type": "text", "value": "AndroidRunner", "down": 0, "up": 1000}

--- a/myexemple/config.json
+++ b/myexemple/config.json
@@ -1,0 +1,18 @@
+{
+  "type": "android",
+  "devices": {
+    "Pixel3W": {}
+  },
+  "repetitions": 1,
+  "apps": [
+    "com.android.chrome"
+  ],
+  "scripts": {
+    "interaction": [
+      {
+        "type": "monkeyadb",
+        "path": "monkey.txt"
+      }
+    ]
+  }
+}

--- a/myexemple/monkey.txt
+++ b/myexemple/monkey.txt
@@ -1,0 +1,3 @@
+{"type": "press", "keys": [{"key": "84"}], "down": 0, "up": 500}
+{"type": "text", "value": "Codex search", "down": 500, "up": 2000}
+{"type": "press", "keys": [{"key": "66"}], "down": 2000, "up": 2500}

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -8,6 +8,7 @@ import paths
 import subprocess
 from AndroidRunner.MonkeyReplay import MonkeyReplay, MonkeyReplayError
 from AndroidRunner.MonkeyRunner import MonkeyRunner, MonkeyRunnerError
+from AndroidRunner.MonkeyAdb import MonkeyAdb
 from AndroidRunner.Python3 import Python3
 from AndroidRunner.Script import Script, ScriptError
 from AndroidRunner.Scripts import Scripts
@@ -219,6 +220,24 @@ class TestMonkeyrunner(object):
             MonkeyRunner(script_path, monkeyrunner_path=monkey_path, monkey_playback_path=monkey_playback_path).execute_script(Mock())
         assert expect_ex.type == MonkeyRunnerError
         assert str(expect_ex.value) == 'SocketException'
+
+
+class TestMonkeyAdb(object):
+    @pytest.fixture()
+    def script_path(self, tmpdir):
+        temp_file = tmpdir.join("script")
+        temp_file.write('{"type": "touch", "x": 10, "y": 20, "down": 0, "up": 10}')
+        return str(temp_file)
+
+    def test_init(self, script_path):
+        runner = MonkeyAdb(script_path)
+        assert runner.path == script_path
+
+    @patch('AndroidRunner.MonkeyAdb.time.sleep')
+    def test_execute_script(self, mock_sleep, script_path):
+        device = Mock()
+        MonkeyAdb(script_path).execute_script(device)
+        device.shell.assert_called_once_with('input tap 10 20')
 
 
 class TestScript(object):


### PR DESCRIPTION
## Summary
- introduce `MonkeyAdb` script to replay monkey.txt with adb
- hook new script type into `Scripts`
- create tests for the new script
- add example experiment using `monkeyadb`
- create another example in `myexemple` folder

## Testing
- `python -m coverage run -m py.test tests/unit/` *(fails: No module named coverage)*
- `py.test tests/unit/` *(fails: ModuleNotFoundError: No module named 'mock')*

------
https://chatgpt.com/codex/tasks/task_e_684bde1dd190832eb8d8700c22b92c23